### PR TITLE
Refactor: Migrate home component from Tailwind CSS to Bootstrap 5

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,13 +11,17 @@ import { MicrophoneViewComponent } from './components/microphone-view/microphone
 import {PromptManager} from './managers/prompt.manager';
 import {AudioRecordingService} from './services/audio-recording.service';
 import {AudioVisualizerService} from './services/audio-visualizer.service';
+import {FooterComponent} from './components/footer/footer.component';
+import {ActionButtonComponent} from './components/action-button/action-button.component';
+import {ContextManager} from './managers/context.manager';
 
 @NgModule({
   declarations: [
     LayoutComponent,
     RootComponent,
 
-
+    ActionButtonComponent,
+    FooterComponent,
     HomeComponent,
     CameraViewComponent,
     MicrophoneViewComponent
@@ -31,6 +35,7 @@ import {AudioVisualizerService} from './services/audio-visualizer.service';
     provideClientHydration(withEventReplay()),
 
     // Managers
+    ContextManager,
     PromptManager,
 
     // Services

--- a/src/app/components/action-button/action-button.component.html
+++ b/src/app/components/action-button/action-button.component.html
@@ -1,0 +1,3 @@
+<button [ngClass]="{'bg-danger':color === 'red', 'bg-white': color === 'white'}" [disabled]="disabled">
+  <i class="bi" [className]="icon"></i>
+</button>

--- a/src/app/components/action-button/action-button.component.scss
+++ b/src/app/components/action-button/action-button.component.scss
@@ -1,0 +1,16 @@
+button {
+  background-color: #222227;
+  height: 40px;
+  font-size: 24px;
+  width: 70px;
+
+  border-radius: 40px;
+
+  &.bg-white {
+    color: black;
+  }
+
+  &:disabled {
+    color: #808080;
+  }
+}

--- a/src/app/components/action-button/action-button.component.ts
+++ b/src/app/components/action-button/action-button.component.ts
@@ -1,0 +1,18 @@
+import {Component, Input} from '@angular/core';
+
+@Component({
+  selector: 'app-action-button',
+  templateUrl: './action-button.component.html',
+  standalone: false,
+  styleUrl: './action-button.component.scss'
+})
+export class ActionButtonComponent {
+  @Input()
+  icon?: string;
+
+  @Input()
+  color: "transparent" | "white" | "red" = "transparent"
+
+  @Input()
+  disabled = false;
+}

--- a/src/app/components/footer/footer.component.html
+++ b/src/app/components/footer/footer.component.html
@@ -1,0 +1,7 @@
+<div class="d-flex align-items-center justify-content-center gap-3">
+  <app-action-button [icon]="'bi-camera-video'" [color]="isCameraOn ? 'white':'transparent'" [disabled]="isPaused" (click)="toggleCamera()"></app-action-button>
+<!--  <app-action-button [icon]="'bi-window-plus'" [disabled]="isPaused"></app-action-button>-->
+  <app-action-button [icon]="'bi-circle'" (click)="captureContext()"></app-action-button>
+  <app-action-button [icon]="isPaused ? 'bi-soundwave' : 'bi-pause-fill'" (click)="togglePause()"></app-action-button>
+  <app-action-button [icon]="'bi-x'" color="red"></app-action-button>
+</div>

--- a/src/app/components/footer/footer.component.ts
+++ b/src/app/components/footer/footer.component.ts
@@ -1,0 +1,53 @@
+import {AfterViewInit, Component, Inject, Input, PLATFORM_ID} from '@angular/core';
+import {EventStore} from '../../stores/event.store';
+import {isPlatformServer} from '@angular/common';
+
+@Component({
+  selector: 'app-footer',
+  templateUrl: './footer.component.html',
+  standalone: false,
+  styleUrl: './footer.component.scss'
+})
+export class FooterComponent implements AfterViewInit {
+
+  @Input()
+  isPaused = true
+
+  @Input()
+  isCameraOn = false;
+
+  constructor(
+    @Inject(PLATFORM_ID) private platformId: Object,
+    private readonly eventStore: EventStore,
+  ) {
+  }
+
+  ngAfterViewInit(): void {
+    if(isPlatformServer(this.platformId)) {
+      return;
+    }
+
+    // const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
+    // // @ts-expect-error
+    // const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
+  }
+
+  captureContext() {
+    this.eventStore.captureContext.next(true);
+  }
+
+  togglePause() {
+    this.isPaused = !this.isPaused;
+
+    if (this.isPaused) {
+      this.isCameraOn = false;
+    }
+
+    this.eventStore.isPaused.next(this.isPaused);
+  }
+
+  toggleCamera() {
+    this.isCameraOn = !this.isCameraOn;
+    //this.eventStore.turnOnCamera();
+  }
+}

--- a/src/app/components/microphone-view/microphone-view.component.html
+++ b/src/app/components/microphone-view/microphone-view.component.html
@@ -1,5 +1,9 @@
 <div id="listening-indicator" class="flex-grow flex flex-col items-center justify-center">
-    <p class="text-lg mb-2 opacity-80">{{ isListening ? 'Listening...' : 'Paused' }}</p>
+    @if(isProcessing) {
+        <p class="text-lg mb-2 opacity-80">Processing...</p>
+    } @else {
+        <p class="text-lg mb-2 opacity-80">{{ isListening ? 'Listening...' : 'Paused' }}</p>
+    }
 
     <canvas class="visualizer d-block rounded-pill mb-3" height="40px" #canvasElement></canvas>
 

--- a/src/app/managers/context.manager.ts
+++ b/src/app/managers/context.manager.ts
@@ -1,0 +1,81 @@
+import {Injectable} from '@angular/core';
+import {EventStore} from '../stores/event.store';
+import {AudioRecordingService} from '../services/audio-recording.service';
+import {AudioVisualizerService} from '../services/audio-visualizer.service';
+import {PromptManager} from './prompt.manager';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ContextManager {
+
+  stream?: MediaStream;
+
+  capturingContext: boolean = false;
+
+  constructor(
+    private readonly eventStore: EventStore,
+    private readonly audioRecordingService: AudioRecordingService,
+    private readonly audioVisualizerService: AudioVisualizerService,
+    private readonly promptManager: PromptManager,
+    ) {
+
+    this.eventStore.captureContext.subscribe(value => {
+      if (value) {
+        this.captureContext();
+      }
+    })
+
+    this.eventStore.isPaused.subscribe(value => {
+      if (value === false) {
+        this.startListening();
+      } else {
+        this.stopListening();
+      }
+    })
+  }
+
+  async startListening() {
+    this.stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    this.audioVisualizerService.visualize(this.stream);
+    this.audioRecordingService.startRecording(this.stream)
+  }
+
+  async stopListening() {
+    if (!this.stream) {
+      return;
+    }
+
+    this.audioRecordingService.stopRecording();
+  }
+
+  async captureContext() {
+    if(this.capturingContext) {
+      return;
+    }
+
+    this.eventStore.isProcessing.next(true);
+    this.capturingContext = true;
+    // Start by transcribing the audio.
+    const audioBlob = await this.audioRecordingService.stopRecording();
+
+    const transcriptionStream = await this.promptManager.transcribe(audioBlob);
+
+    let transcribedText = '';
+    for await (const chunk of transcriptionStream) {
+      this.eventStore.transcriptionAvailable.next(chunk);
+      transcribedText += chunk;
+    }
+
+    const agentResponseStream = this.promptManager.promptStreaming(transcribedText);
+
+    for await (const chunk of agentResponseStream) {
+      this.eventStore.agentResponseAvailable.next(chunk);
+    }
+
+    // Yield again
+    this.capturingContext = false;
+    this.eventStore.isProcessing.next(false);
+    this.startListening()
+  }
+}

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -1,61 +1,70 @@
-<header class="d-flex justify-content-between align-items-center">
-  <h1 class="fs-5 fw-semibold">OnDevice Astra</h1>
+<div class="d-flex flex-column">
+<header class="d-flex justify-content-center mt-5">
+  <h1 class="fs-5 fw-semibold"><i class="bi bi-soundwave"></i> Live</h1>
 </header>
 
 <div class="view-container">
 
-<!-- Microphone View -->
-<div *ngIf="currentView === 'microphone'" id="microphoneView" class="d-flex flex-column vh-100 justify-content-between p-3 p-md-4 fade-in">
-  <!-- Main content area for Microphone View -->
-  <div class="flex-grow-1 d-flex flex-column align-items-center justify-content-center">
+  <div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); z-index: 1000;">
     <app-microphone-view></app-microphone-view>
   </div>
-</div>
 
-<!-- App Camera View Component -->
-<app-camera-view
-  *ngIf="currentView === 'camera'"
-  [currentView]="currentView"
-  [startWithFileUpload]="startCameraWithFileUpload"
-  (viewChange)="handleCameraViewChange($event)"
-  (message)="handleCameraMessage($event)"
-  (fileUploadRequested)="handleFileUploadInCameraRequest()">
-</app-camera-view>
+  <!-- App Camera View Component -->
+  <app-camera-view
+    *ngIf="currentView === 'camera'"
+    [currentView]="currentView"
+    [startWithFileUpload]="startCameraWithFileUpload"
+    (viewChange)="handleCameraViewChange($event)"
+    (message)="handleCameraMessage($event)"
+    (fileUploadRequested)="handleFileUploadInCameraRequest()">
+  </app-camera-view>
 
-<!-- Message Box -->
-<div *ngIf="isMessageBoxVisible" id="message-box"
-    class="position-fixed start-50 translate-middle-x bg-dark text-white text-center py-2 px-3 rounded-3 shadow-lg z-3 message-box-custom-bottom"
-    [class.opacity-0]="!isMessageBoxVisible">
-  {{ messageBoxText }}
-</div>
+  <!-- Message Box -->
+  <div *ngIf="isMessageBoxVisible" id="message-box"
+       class="position-fixed start-50 translate-middle-x bg-dark text-white text-center py-2 px-3 rounded-3 shadow-lg z-3 message-box-custom-bottom"
+       [class.opacity-0]="!isMessageBoxVisible">
+    {{ messageBoxText }}
+  </div>
 </div>
 
 
 <!-- Footer Controls -->
+
+<app-footer class="mt-4"></app-footer>
+
 <footer class="d-flex justify-content-around align-items-center p-3">
-  <button id="cameraBtn" (click)="openCameraView()" class="icon-btn rounded-circle p-3 hover-scale-110">
-    <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z" />
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z" />
-    </svg>
-  </button>
+<!--  <button id="cameraBtn" (click)="openCameraView()" class="icon-btn rounded-circle p-3 hover-scale-110">-->
+<!--    <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">-->
+<!--      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"-->
+<!--            d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z"/>-->
+<!--      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z"/>-->
+<!--    </svg>-->
+<!--  </button>-->
 
-  <button id="micBtn" (click)="handleToggleListen()"
-          class="rounded-circle p-4 hover-scale-110"
-          [class.bg-white]="isListening" [class.text-primary]="isListening"
-          [class.bg-danger]="!isListening" [class.text-white]="!isListening"
-          [class.pulsing-glow]="isListening">
-    <svg *ngIf="!isListening" id="micIcon" xmlns="http://www.w3.org/2000/svg" class="h-10 w-10" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M7 4a3 3 0 016 0v4a3 3 0 11-6 0V4zm5 4a1 1 0 11-2 0V4a1 1 0 112 0v4zM3 9a1 1 0 011-1h1.172a4 4 0 013.998 4.223l.135.811a4.002 4.002 0 01-3.182 3.965A4.002 4.002 0 014.172 15H4a1 1 0 110-2h.172a2 2 0 001.995-2.223l-.135-.81a2 2 0 00-1.995-1.744H4a1 1 0 01-1-1zm12.172 2.223a4 4 0 01-3.998-4.223H15a1 1 0 110 2h-.172a2 2 0 00-1.995 2.223l.135.81a2 2 0 001.995 1.744H16a1 1 0 110 2h-.828a4.002 4.002 0 01-3.998-3.777l-.135-.811A4 4 0 0111.828 9H13a1 1 0 110 2h-.172z" clip-rule="evenodd" />
-    </svg>
-    <svg *ngIf="isListening" id="pauseIcon" xmlns="http://www.w3.org/2000/svg" class="h-10 w-10" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zM7 8a1 1 0 012 0v4a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v4a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd" />
-    </svg>
-  </button>
+<!--  <button id="micBtn" (click)="handleToggleListen()"-->
+<!--          class="rounded-circle p-4 hover-scale-110"-->
+<!--          [class.bg-white]="isListening" [class.text-primary]="isListening"-->
+<!--          [class.bg-danger]="!isListening" [class.text-white]="!isListening"-->
+<!--          [class.pulsing-glow]="isListening">-->
+<!--    <svg *ngIf="!isListening" id="micIcon" xmlns="http://www.w3.org/2000/svg" class="h-10 w-10" viewBox="0 0 20 20"-->
+<!--         fill="currentColor">-->
+<!--      <path fill-rule="evenodd"-->
+<!--            d="M7 4a3 3 0 016 0v4a3 3 0 11-6 0V4zm5 4a1 1 0 11-2 0V4a1 1 0 112 0v4zM3 9a1 1 0 011-1h1.172a4 4 0 013.998 4.223l.135.811a4.002 4.002 0 01-3.182 3.965A4.002 4.002 0 014.172 15H4a1 1 0 110-2h.172a2 2 0 001.995-2.223l-.135-.81a2 2 0 00-1.995-1.744H4a1 1 0 01-1-1zm12.172 2.223a4 4 0 01-3.998-4.223H15a1 1 0 110 2h-.172a2 2 0 00-1.995 2.223l.135.81a2 2 0 001.995 1.744H16a1 1 0 110 2h-.828a4.002 4.002 0 01-3.998-3.777l-.135-.811A4 4 0 0111.828 9H13a1 1 0 110 2h-.172z"-->
+<!--            clip-rule="evenodd"/>-->
+<!--    </svg>-->
+<!--    <svg *ngIf="isListening" id="pauseIcon" xmlns="http://www.w3.org/2000/svg" class="h-10 w-10" viewBox="0 0 20 20"-->
+<!--         fill="currentColor">-->
+<!--      <path fill-rule="evenodd"-->
+<!--            d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zM7 8a1 1 0 012 0v4a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v4a1 1 0 102 0V8a1 1 0 00-1-1z"-->
+<!--            clip-rule="evenodd"/>-->
+<!--    </svg>-->
+<!--  </button>-->
 
-  <button id="addFileBtn" (click)="triggerOrRequestFileUpload()" class="icon-btn rounded-circle p-3 hover-scale-110">
-    <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
-    </svg>
-  </button>
+<!--  <button id="addFileBtn" (click)="triggerOrRequestFileUpload()" class="icon-btn rounded-circle p-3 hover-scale-110">-->
+<!--    <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">-->
+<!--      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"-->
+<!--            d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"/>-->
+<!--    </svg>-->
+<!--  </button>-->
 </footer>
+</div>

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -1,13 +1,13 @@
-<header class="flex justify-between items-center">
-  <h1 class="text-xl font-semibold">OnDevice Astra</h1>
+<header class="d-flex justify-content-between align-items-center">
+  <h1 class="fs-5 fw-semibold">OnDevice Astra</h1>
 </header>
 
 <div class="view-container">
 
 <!-- Microphone View -->
-<div *ngIf="currentView === 'microphone'" id="microphoneView" class="flex flex-col h-screen justify-between p-4 md:p-6 fade-in">
+<div *ngIf="currentView === 'microphone'" id="microphoneView" class="d-flex flex-column vh-100 justify-content-between p-3 p-md-4 fade-in">
   <!-- Main content area for Microphone View -->
-  <div class="flex-grow flex flex-col items-center justify-center">
+  <div class="flex-grow-1 d-flex flex-column align-items-center justify-content-center">
     <app-microphone-view></app-microphone-view>
   </div>
 </div>
@@ -24,7 +24,7 @@
 
 <!-- Message Box -->
 <div *ngIf="isMessageBoxVisible" id="message-box"
-    class="fixed bottom-24 left-1/2 -translate-x-1/2 bg-gray-800 text-white text-center py-2 px-4 rounded-lg shadow-lg transition-opacity duration-300 z-50"
+    class="position-fixed start-50 translate-middle-x bg-dark text-white text-center py-2 px-3 rounded-3 shadow-lg z-3 message-box-custom-bottom"
     [class.opacity-0]="!isMessageBoxVisible">
   {{ messageBoxText }}
 </div>
@@ -32,8 +32,8 @@
 
 
 <!-- Footer Controls -->
-<footer class="flex justify-around items-center p-4">
-  <button id="cameraBtn" (click)="openCameraView()" class="icon-btn rounded-full p-4 transition-transform duration-200 ease-in-out hover:scale-110">
+<footer class="d-flex justify-content-around align-items-center p-3">
+  <button id="cameraBtn" (click)="openCameraView()" class="icon-btn rounded-circle p-3 hover-scale-110">
     <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z" />
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z" />
@@ -41,9 +41,9 @@
   </button>
 
   <button id="micBtn" (click)="handleToggleListen()"
-          class="rounded-full p-6 transition-transform duration-200 ease-in-out hover:scale-110 focus:outline-none focus:ring-4 focus:ring-white focus:ring-opacity-50"
-          [class.bg-white]="isListening" [class.text-blue-600]="isListening"
-          [class.bg-red-500]="!isListening" [class.text-white]="!isListening"
+          class="rounded-circle p-4 hover-scale-110"
+          [class.bg-white]="isListening" [class.text-primary]="isListening"
+          [class.bg-danger]="!isListening" [class.text-white]="!isListening"
           [class.pulsing-glow]="isListening">
     <svg *ngIf="!isListening" id="micIcon" xmlns="http://www.w3.org/2000/svg" class="h-10 w-10" viewBox="0 0 20 20" fill="currentColor">
       <path fill-rule="evenodd" d="M7 4a3 3 0 016 0v4a3 3 0 11-6 0V4zm5 4a1 1 0 11-2 0V4a1 1 0 112 0v4zM3 9a1 1 0 011-1h1.172a4 4 0 013.998 4.223l.135.811a4.002 4.002 0 01-3.182 3.965A4.002 4.002 0 014.172 15H4a1 1 0 110-2h.172a2 2 0 001.995-2.223l-.135-.81a2 2 0 00-1.995-1.744H4a1 1 0 01-1-1zm12.172 2.223a4 4 0 01-3.998-4.223H15a1 1 0 110 2h-.172a2 2 0 00-1.995 2.223l.135.81a2 2 0 001.995 1.744H16a1 1 0 110 2h-.828a4.002 4.002 0 01-3.998-3.777l-.135-.811A4 4 0 0111.828 9H13a1 1 0 110 2h-.172z" clip-rule="evenodd" />
@@ -53,7 +53,7 @@
     </svg>
   </button>
 
-  <button id="addFileBtn" (click)="triggerOrRequestFileUpload()" class="icon-btn rounded-full p-4 transition-transform duration-200 ease-in-out hover:scale-110">
+  <button id="addFileBtn" (click)="triggerOrRequestFileUpload()" class="icon-btn rounded-circle p-3 hover-scale-110">
     <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
     </svg>

--- a/src/app/pages/home/home.component.scss
+++ b/src/app/pages/home/home.component.scss
@@ -44,3 +44,11 @@
 /* Hide scrollbar for cleaner look */
 .no-scrollbar::-webkit-scrollbar { display: none; }
 .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
+
+.message-box-custom-bottom {
+  bottom: 6rem; /* Equivalent to Tailwind's bottom-24 */
+}
+
+.hover-scale-110:hover {
+  transform: scale(1.1);
+}

--- a/src/app/pages/home/home.component.scss
+++ b/src/app/pages/home/home.component.scss
@@ -4,7 +4,7 @@
   background-size: 200% 200%;
   animation: gradient-animation 10s ease infinite;
   margin-top:50px;
-  height: calc(100vh - 200px);
+  height: calc(100vh - 250px);
 }
 
 

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -1,8 +1,10 @@
-import {Component, ViewChild, AfterViewInit, Inject} from '@angular/core';
-import { CameraViewComponent } from '../../components/camera-view/camera-view.component';
+import {Component, ViewChild, AfterViewInit, Inject, OnInit} from '@angular/core';
+import {CameraViewComponent} from '../../components/camera-view/camera-view.component';
 import {BaseComponent} from '../../components/base/base.component';
 import {DOCUMENT} from '@angular/common';
 import {EventStore} from '../../stores/event.store';
+import {ContextManager} from '../../managers/context.manager';
+
 // MicrophoneComponent is not needed for ViewChild access if interaction is only through Input/Output
 
 @Component({
@@ -11,31 +13,48 @@ import {EventStore} from '../../stores/event.store';
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.scss']
 })
-export class HomeComponent extends BaseComponent {
+export class HomeComponent extends BaseComponent implements OnInit {
   currentView: 'microphone' | 'camera' = 'microphone';
   messageBoxText: string | null = null;
   isMessageBoxVisible: boolean = false;
   startCameraWithFileUpload: boolean = false;
 
   // New property for MicrophoneComponent
-  isListening: boolean = false;
+  isPaused: boolean = false;
 
   @ViewChild(CameraViewComponent) cameraViewInstance!: CameraViewComponent;
 
   constructor(
     @Inject(DOCUMENT) document: Document,
     private readonly eventStore: EventStore,
+    private readonly contextManager: ContextManager,
   ) {
     super(document);
   }
 
-  handleToggleListen() {
-    this.isListening = !this.isListening;
-    this.eventStore.recordingStatus.next(this.isListening);
+  override ngOnInit() {
+    super.ngOnInit();
 
-    if(this.isListening) {
-      this.showMessage("Press pause for the transcription to start.");
-    }
+    this.subscriptions.push(this.eventStore.transcriptionAvailable.subscribe(value => {
+
+    }));
+
+    this.subscriptions.push(this.eventStore.agentResponseAvailable.subscribe(value => {
+
+    }));
+
+    this.subscriptions.push(this.eventStore.isPaused.subscribe(value => {
+      if (value === undefined) {
+        return;
+      }
+      this.isPaused = value;
+
+      if(this.isPaused){
+
+      } else {
+        this.showMessage("Press the circle to process content.");
+      }
+    }))
   }
 
   // --- Camera Interaction ---
@@ -59,7 +78,7 @@ export class HomeComponent extends BaseComponent {
   }
 
   handleFileUploadInCameraRequest() {
-      this.startCameraWithFileUpload = false;
+    this.startCameraWithFileUpload = false;
   }
 
   triggerOrRequestFileUpload() {

--- a/src/app/services/audio-recording.service.ts
+++ b/src/app/services/audio-recording.service.ts
@@ -1,7 +1,9 @@
 import {ElementRef, Inject, Injectable, PLATFORM_ID} from '@angular/core';
 import {isPlatformServer} from "@angular/common";
 
-@Injectable()
+@Injectable({
+    providedIn: 'root'
+})
 export class AudioRecordingService {
 
   private canvasElement?: ElementRef;

--- a/src/app/services/audio-visualizer.service.ts
+++ b/src/app/services/audio-visualizer.service.ts
@@ -1,6 +1,8 @@
 import {ElementRef, Injectable} from '@angular/core';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class AudioVisualizerService {
   private canvasElement?: ElementRef;
 

--- a/src/app/stores/event.store.ts
+++ b/src/app/stores/event.store.ts
@@ -5,5 +5,13 @@ import {BehaviorSubject} from 'rxjs';
   providedIn: 'root'
 })
 export class EventStore {
-  public readonly recordingStatus = new BehaviorSubject<void | boolean>(undefined);
+  public readonly isPaused = new BehaviorSubject<void | boolean>(undefined);
+
+  public readonly captureContext = new BehaviorSubject<void | boolean>(undefined);
+
+  public readonly transcriptionAvailable = new BehaviorSubject<void | string>(undefined);
+
+  public readonly agentResponseAvailable = new BehaviorSubject<void | string>(undefined);
+
+  public readonly isProcessing = new BehaviorSubject<void | boolean>(undefined);
 }

--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-4Q6Gf2aSP4eDXB8Miphtr37CMZZQ5oXLH2yaXMJ2w8e2ZtHTl7GptT4jmndRuHDT" crossorigin="anonymous">
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js" integrity="sha384-j1CDi7MgGQ12Z7Qab0qlWQ/Qqz24Gc6BM0thvEMVjHnfYGF0rmFCozFSxQBxwHKO" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
 </head>
 <body class="gemini-gradient-bg text-white overflow-hidden">


### PR DESCRIPTION
I've migrated the styling of your HomeComponent (template and styles) from Tailwind CSS to Bootstrap 5.

Key changes:
- I replaced Tailwind utility classes in `home.component.html` with their corresponding Bootstrap 5 equivalents.
- I updated class names for flexbox, padding, margins, typography, colors, and positioning.
- I introduced custom CSS classes in `home.component.scss` for styles where direct Bootstrap equivalents were not available or suitable:
    - `.message-box-custom-bottom` for specific positioning.
    - `.hover-scale-110` for a hover scaling effect on buttons.
- I ensured existing custom styles and animations (`fade-in`, `pulsing-glow`, `icon-btn`, gradient background) were preserved.
- I removed Tailwind-specific focus ring utilities, relying on Bootstrap's default button focus styling.

The SVG icon size classes (e.g., `h-8`, `w-8`) have been kept in the HTML. These may require further attention if the global Tailwind stylesheet defining them is removed in the future, potentially by switching to direct width/height attributes on the SVGs.