### PR TITLE
feat: Implement camera on/off event handling

### DIFF
--- a/src/app/components/footer/footer.component.ts
+++ b/src/app/components/footer/footer.component.ts
@@ -48,6 +48,6 @@ export class FooterComponent implements AfterViewInit {
 
   toggleCamera() {
     this.isCameraOn = !this.isCameraOn;
-    //this.eventStore.turnOnCamera();
+    this.eventStore.isCameraOn.next(this.isCameraOn); // Dispatch the event
   }
 }

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -54,7 +54,18 @@ export class HomeComponent extends BaseComponent implements OnInit {
       } else {
         this.showMessage("Press the circle to process content.");
       }
-    }))
+    }));
+
+    this.subscriptions.push(this.eventStore.isCameraOn.subscribe(value => {
+      if (value === undefined) {
+        return;
+      }
+      if (value) { // If camera is on
+        this.currentView = 'camera';
+      } else { // If camera is off
+        this.currentView = 'microphone';
+      }
+    }));
   }
 
   // --- Camera Interaction ---

--- a/src/app/stores/event.store.ts
+++ b/src/app/stores/event.store.ts
@@ -14,4 +14,6 @@ export class EventStore {
   public readonly agentResponseAvailable = new BehaviorSubject<void | string>(undefined);
 
   public readonly isProcessing = new BehaviorSubject<void | boolean>(undefined);
+
+  public readonly isCameraOn = new BehaviorSubject<void | boolean>(undefined); // New event
 }


### PR DESCRIPTION
Adds a new event `isCameraOn` to the `EventStore` to track camera state.

The `FooterComponent` now dispatches this event when the camera button is toggled.

The `HomeComponent` subscribes to this event and updates its `currentView` to 'camera' or 'microphone' based on the camera's state.